### PR TITLE
Add proof of concept for cert hash reading

### DIFF
--- a/src/Notary/Lib.fs
+++ b/src/Notary/Lib.fs
@@ -1,0 +1,37 @@
+﻿namespace Notary
+
+    module Lib =
+        open System
+        open System.Diagnostics
+        open System.Text.RegularExpressions
+
+        let extractCertHash (certUtilExeFilePath: string) (pfxFilePath: string) =
+            let psi =
+                ProcessStartInfo(
+                    FileName = certUtilExeFilePath,
+                    Arguments = sprintf "-dump %s" pfxFilePath,
+                    RedirectStandardOutput = true,
+                    UseShellExecute = false,
+                    CreateNoWindow = true,
+                    WindowStyle = ProcessWindowStyle.Hidden)
+            let proc = Process.Start(psi)
+            let stdOut = proc.StandardOutput.ReadToEnd()
+
+            // This could definitely be loads better
+            stdOut
+            |> (fun str -> str.Split([| Environment.NewLine |], StringSplitOptions.RemoveEmptyEntries))
+            |> Array.filter (fun (str: string) -> str.StartsWith("Cert Hash(sha1): "))
+            |> Seq.last
+            |> (fun str -> Regex.Replace(str, "Cert Hash\(sha1\): ", ""))
+            |> (fun str -> str.Trim())
+            |> (fun str -> str.Replace(" ", ""))
+            |> (fun str -> str.ToUpperInvariant())
+
+        let isFileSignedByCertHash (filePath: string) (certHash: string) =
+            // TODO
+            false
+
+        let isFileSignedByPfx (certUtilExeFilePath: string) (pfxFilePath: string) (filePath: string) =
+            pfxFilePath
+            |> extractCertHash certUtilExeFilePath
+            |> isFileSignedByCertHash filePath

--- a/src/Notary/Notary.fsproj
+++ b/src/Notary/Notary.fsproj
@@ -55,6 +55,7 @@
   <Import Project="$(FSharpTargetsPath)" />
   <ItemGroup>
     <Compile Include="AssemblyInfo.fs" />
+    <Compile Include="Lib.fs" />
     <Compile Include="Program.fs" />
     <None Include="App.config" />
     <Content Include="packages.config" />

--- a/src/Notary/Program.fs
+++ b/src/Notary/Program.fs
@@ -1,7 +1,27 @@
 ﻿// Learn more about F# at http://fsharp.org
 // See the 'F# Tutorial' project for more help.
 
+open Notary
+
+let private _basicFail () =
+    printfn "TODO: Usage"
+    1
+
 [<EntryPoint>]
 let main argv =
-    printfn "%A" argv
-    0 // return an integer exit code
+    // TODO: Put proper CLI parsing in place
+
+    if Array.isEmpty argv then _basicFail()
+    else
+        match Array.head argv with
+        | "getPfxCertHash" ->
+            let certUtilExeFilePath = @"C:\WINDOWS\System32\certutil.exe"
+
+            argv
+            |> Array.item 1
+            |> Lib.extractCertHash certUtilExeFilePath
+            |> printfn "%s"
+
+            0
+        | _ ->
+            _basicFail()


### PR DESCRIPTION
Usage: `Notary.exe getPfxCertHash "C:\mycert.pfx"`