### PR TITLE
Implement check to see if file is already signed

### DIFF
--- a/src/Notary/Program.fs
+++ b/src/Notary/Program.fs
@@ -2,26 +2,46 @@
 // See the 'F# Tutorial' project for more help.
 
 open Notary
+open System
 
 let private _basicFail () =
     printfn "TODO: Usage"
     1
 
+let private _block () = Console.ReadLine()
+
 [<EntryPoint>]
 let main argv =
-    // TODO: Put proper CLI parsing in place
+    printfn "argv: %A" argv
 
+    // TODO: Put proper CLI parsing in place
     if Array.isEmpty argv then _basicFail()
     else
-        match Array.head argv with
-        | "getPfxCertHash" ->
-            let certUtilExeFilePath = @"C:\WINDOWS\System32\certutil.exe"
+        // TODO: Unhardcode these
+        let certutilExeFilePath = @"C:\WINDOWS\System32\certutil.exe"
+        let signtoolExeFilePath = @"C:\Program Files (x86)\Windows Kits\10\bin\10.0.15063.0\x64\signtool.exe"
 
-            argv
-            |> Array.item 1
-            |> Lib.extractCertHash certUtilExeFilePath
-            |> printfn "%s"
+        try
+            match Array.head argv with
+            | "getPfxCertHash" ->
+                argv
+                |> Array.item 1
+                |> Lib.getPfxCertHash certutilExeFilePath
+                |> printfn "%s"
 
-            0
-        | _ ->
-            _basicFail()
+                _block()
+                0
+            | "checkIfAlreadySigned" ->
+                let pfxFilePath = argv.[1]
+
+                argv
+                |> Array.item 2
+                |> Lib.isFileSignedByPfx signtoolExeFilePath certutilExeFilePath pfxFilePath
+                |> printfn "%b"
+
+                _block()
+                0
+            | _ ->
+                _basicFail()
+        with
+        | _ -> _basicFail()


### PR DESCRIPTION
Usage:

```
Notary.exe checkIfAlreadySigned "C:\MyCert.pfx" "C:\MyApp.exe"
```

Can take a cert SHA1 hash, and tell you whether a given file has already been signed by that cert.