### PR TITLE
Idempotent Signing Proof of Concept

### DIFF
--- a/src/Notary/Lib.fs
+++ b/src/Notary/Lib.fs
@@ -1,22 +1,39 @@
 ﻿namespace Notary
 
-    module Lib =
-        open System
+    module Shell =
         open System.Diagnostics
-        open System.Text.RegularExpressions
 
-        let getPfxCertHash certutilExeFilePath pfxFilePath =
+        type ProcessResult =
+            {
+                proc  : Process
+                stdOut: string
+                stdErr: string
+            }
+
+        let run filename arguments =
             let psi =
                 ProcessStartInfo(
-                    FileName               = certutilExeFilePath,
-                    Arguments              = sprintf "-dump %s" pfxFilePath,
+                    FileName               = filename,
+                    Arguments              = arguments,
                     RedirectStandardOutput = true,
+                    RedirectStandardError  = true,
                     UseShellExecute        = false,
                     CreateNoWindow         = true,
                     WindowStyle            = ProcessWindowStyle.Hidden)
+
             let proc = Process.Start(psi)
             let stdOut = proc.StandardOutput.ReadToEnd()
-            proc.WaitForExit()
+            let stdErr = proc.StandardError.ReadToEnd()
+
+            { proc = proc; stdOut = stdOut; stdErr = stdErr }
+
+    module Lib =
+        open System
+        open System.Text.RegularExpressions
+        open Shell
+
+        let getPfxCertHash certutil pfx =
+            let { stdOut = stdOut } = Shell.run certutil (sprintf "-dump %s" pfx)
 
             // This could definitely be loads better
             stdOut
@@ -28,21 +45,55 @@
             |> (fun str -> str.Replace(" ", ""))
             |> (fun str -> str.ToUpperInvariant())
 
-        let isFileSignedByCertHash signtoolExeFilePath filePath certHash =
-            let psi =
-                ProcessStartInfo(
-                    FileName               = signtoolExeFilePath,
-                    Arguments              = sprintf "verify /q /pa /sha1 %s \"%s\"" certHash filePath,
-                    RedirectStandardOutput = false,
-                    UseShellExecute        = false,
-                    CreateNoWindow         = true,
-                    WindowStyle            = ProcessWindowStyle.Hidden)
-            let proc = Process.Start(psi)
-            proc.WaitForExit()
+        let isFileSignedByCertHash signtool filePath certHash =
+            let { proc = proc; stdOut = stdOut } =
+                filePath
+                |> sprintf "verify /v /all /pa /sha1 %s \"%s\"" certHash
+                |> Shell.run signtool
 
-            proc.ExitCode = 0
+            proc.ExitCode = 0 ||
+                // This doesn't really feel great, but I don't see another way right now
+                let prefixText = "number of signatures successfully verified:"
+                stdOut
+                |> (fun str -> str.Split([| Environment.NewLine |], StringSplitOptions.RemoveEmptyEntries))
+                |> Array.map (fun str -> str.ToLowerInvariant())
+                |> Array.find (fun str -> str.StartsWith(prefixText))
+                |> (fun str -> str.Trim())
+                |> (fun str -> str.Replace(prefixText, ""))
+                |> int
+                |> fun i -> i <> 0
 
-        let isFileSignedByPfx signtoolExeFilePath certutilExeFilePath pfxFilePath filePath =
-            pfxFilePath
-            |> getPfxCertHash certutilExeFilePath
-            |> isFileSignedByCertHash signtoolExeFilePath filePath
+        let isFileSignedByPfx signtool certutil pfx filePath =
+            pfx
+            |> getPfxCertHash certutil
+            |> isFileSignedByCertHash signtool filePath
+
+        let signIfNotSigned signtool certutil pfx password filePaths =
+            let (doNotNeedSigning, needSigning) =
+                filePaths
+                |> Array.partition (isFileSignedByPfx signtool certutil pfx)
+
+            printfn "doNotNeedSigning: %A" doNotNeedSigning
+            printfn "needSigning: %A" needSigning
+
+            let timestampAlgo = "sha256"
+            let timestampUrl  = "http://sha256timestamp.ws.symantec.com/sha256/timestamp"
+            let filePathsAsSingleString =
+                needSigning
+                |> Array.map (sprintf "\"%s\"")
+                |> String.concat " "
+
+            let args =
+                sprintf
+                    "sign /v /as /td \"%s\" /tr \"%s\" /f \"%s\" /p \"%s\" %s"
+                    timestampAlgo
+                    timestampUrl
+                    pfx
+                    password
+                    filePathsAsSingleString
+
+            let { proc = proc; stdOut = stdOut; stdErr = stdErr } = Shell.run signtool args
+
+            printfn "stdOut  : %s" stdOut
+            printfn "stdErr  : %s" stdErr
+            printfn "exitCode: %d" proc.ExitCode

--- a/src/Notary/Program.fs
+++ b/src/Notary/Program.fs
@@ -18,30 +18,46 @@ let main argv =
     if Array.isEmpty argv then _basicFail()
     else
         // TODO: Unhardcode these
-        let certutilExeFilePath = @"C:\WINDOWS\System32\certutil.exe"
-        let signtoolExeFilePath = @"C:\Program Files (x86)\Windows Kits\10\bin\10.0.15063.0\x64\signtool.exe"
+        let certutil = @"C:\WINDOWS\System32\certutil.exe"
+        let signtool = @"C:\Program Files (x86)\Windows Kits\10\bin\10.0.15063.0\x64\signtool.exe"
 
         try
             match Array.head argv with
             | "getPfxCertHash" ->
-                argv
-                |> Array.item 1
-                |> Lib.getPfxCertHash certutilExeFilePath
+                let pfx = argv.[1]
+
+                pfx
+                |> Lib.getPfxCertHash certutil
                 |> printfn "%s"
 
                 _block()
                 0
             | "checkIfAlreadySigned" ->
-                let pfxFilePath = argv.[1]
+                let pfx  = argv.[1]
+                let file = argv.[2]
 
-                argv
-                |> Array.item 2
-                |> Lib.isFileSignedByPfx signtoolExeFilePath certutilExeFilePath pfxFilePath
+                file
+                |> Lib.isFileSignedByPfx signtool certutil pfx
                 |> printfn "%b"
+
+                _block()
+                0
+            | "ensureSigned" ->
+                let pfx       = argv.[1]
+                let password  = argv.[2]
+                let filePaths =
+                    argv
+                    |> Array.skip 3
+                    |> Array.map (fun str -> str.Trim())
+
+                Lib.signIfNotSigned signtool certutil pfx password filePaths
 
                 _block()
                 0
             | _ ->
                 _basicFail()
         with
-        | _ -> _basicFail()
+        | ex ->
+            printfn "%s" ex.Message
+            _block()
+            _basicFail()


### PR DESCRIPTION
Usage:
```
Notary.exe ensureSigned "C:\SomeCert.pfx" "hunter2" "SomeAssembly.dll" "SomeApp.exe" [...]
```