### PR TITLE
Stop taking a (string -> string) option

### DIFF
--- a/src/Notary/Lib.fs
+++ b/src/Notary/Lib.fs
@@ -15,7 +15,7 @@ module Lib =
                 pfx
                 |> sprintf "-dump %s"
                 |> Shell.createStartInfo certutil
-                |> Shell.printFilteredCommand None
+                |> Shell.printCommand
                 |> Shell.runSync
 
             proc
@@ -38,7 +38,7 @@ module Lib =
             filePath
             |> sprintf "verify /v /all /pa /sha1 %s \"%s\"" certHash
             |> Shell.createStartInfo signtool
-            |> Shell.printFilteredCommand None
+            |> Shell.printCommand
             |> Shell.runSync
 
         proc.ExitCode = 0 ||
@@ -92,7 +92,7 @@ module Lib =
             let { proc = proc; stdOut = stdOut; stdErr = stdErr } =
                 args
                 |> Shell.createStartInfo signtool
-                |> Shell.printFilteredCommand (Some (fun str -> Regex.Replace(str, "/p [^ ]+ ", "/p [FILTERED] ")))
+                |> Shell.printCommandFiltered (fun str -> Regex.Replace(str, "/p [^ ]+ ", "/p [FILTERED] "))
                 |> Shell.runSync
 
             proc

--- a/src/Notary/Shell.fs
+++ b/src/Notary/Shell.fs
@@ -40,17 +40,16 @@ module Shell =
     let filterCommand filter startInfo =
         startInfo
         |> getCommandText
-        |> (fun str ->
-                match filter with
-                | Some fn -> fn str
-                | None -> str)
+        |> filter
 
-    let printFilteredCommand filter startInfo =
+    let printCommandFiltered filter startInfo =
         startInfo
         |> filterCommand filter
         |> printfn "%s"
 
         startInfo
+
+    let printCommand = printCommandFiltered id
 
     let printIfZeroExit message (proc: Process) =
         if proc.ExitCode = 0 then printfn "%s" message else ()
@@ -72,7 +71,7 @@ module Shell =
     let printCommand filter (procResult: ProcessResult) =
         procResult
         |> (fun { proc = proc } -> proc.StartInfo)
-        |> printFilteredCommand filter
+        |> printCommandFiltered filter
         |> ignore
 
         procResult


### PR DESCRIPTION
Just take the function and always call it. Identity can replace the None case.