### PR TITLE
fix: Further misc improvement

### DIFF
--- a/src/Notary/Args.fs
+++ b/src/Notary/Args.fs
@@ -35,7 +35,7 @@ module Args =
         | Pfx _ -> "pfx filepath"
         | Password _ -> "password for pfx file"
         | Files _ -> "files which will be checked for having been signed by the given pfx file"
-  and NotaryArgs =
+  and [<RequireSubcommand>] NotaryArgs =
   | [<CliPrefix(CliPrefix.None)>] Detect of ParseResults<DetectArgs>
   | [<CliPrefix(CliPrefix.None)>] Print of ParseResults<PrintArgs>
   | [<CliPrefix(CliPrefix.None)>] Sign of ParseResults<SignArgs>

--- a/src/Notary/Args.fs
+++ b/src/Notary/Args.fs
@@ -1,71 +1,71 @@
 namespace Notary.CommandLine
 
 module Args =
-    open Argu
-    open System
+  open Argu
+  open System
 
-    type DetectArgs =
-    | [<Mandatory>] Pfx of ``pfx filepath``:string
-    | [<Mandatory>] Password of string
-    | [<MainCommand; ExactlyOnce; Last>] File of ``file to check``:string
-    with
-      interface IArgParserTemplate with
-        member this.Usage =
-          match this with
-          | Pfx _ -> "pfx filepath"
-          | Password _ -> "password for pfx file"
-          | File _ -> "file which will be checked for having been signed by the given pfx file"
-    and PrintArgs =
-    | [<Mandatory>] Password of string
-    | [<MainCommand; ExactlyOnce; Last>] Pfx of ``pfx filepath``:string
-    with
-      interface IArgParserTemplate with
-        member this.Usage =
-          match this with
-          | Password _ -> "password for pfx file"
-          | Pfx _ -> "pfx filepath"
-    and SignArgs =
-    | [<Mandatory>] Pfx of ``pfx filepath``:string
-    | [<Mandatory>] Password of string
-    | [<MainCommand; ExactlyOnce; Last>] Files of ``files to check``:string list
-    with
-      interface IArgParserTemplate with
-        member this.Usage =
-          match this with
-          | Pfx _ -> "pfx filepath"
-          | Password _ -> "password for pfx file"
-          | Files _ -> "files which will be checked for having been signed by the given pfx file"
-    and NotaryArgs =
-    | [<CliPrefix(CliPrefix.None)>] Detect of ParseResults<DetectArgs>
-    | [<CliPrefix(CliPrefix.None)>] Print of ParseResults<PrintArgs>
-    | [<CliPrefix(CliPrefix.None)>] Sign of ParseResults<SignArgs>
-    | [<Inherit>] Certutil of path:string
-    | [<Inherit>] Signtool of path:string
-    | [<Inherit; AltCommandLine("-v"); Hidden>] Verbose // TODO
-    | [<Inherit; AltCommandLine("-q"); Hidden>] Quiet // TODO
-    with
-      interface IArgParserTemplate with
-        member this.Usage =
-          match this with
-          | Detect _ -> "detect whether a file is already signed by the specified pfx file"
-          | Print _ -> "print the sha1 hash of a given pfx certificate file"
-          | Sign _ -> "sign files with the given pfx certificate only if they're not already signed by that same certificate"
-          | Certutil _ -> "certutil.exe filepath"
-          | Signtool _ -> "signtool.exe filepath"
-          | Verbose -> "Print more detailed output to console"
-          | Quiet -> "Print no output to console"
+  type DetectArgs =
+  | [<Mandatory>] Pfx of ``pfx filepath``:string
+  | [<Mandatory>] Password of string
+  | [<MainCommand; ExactlyOnce; Last>] File of ``file to check``:string
+  with
+    interface IArgParserTemplate with
+      member this.Usage =
+        match this with
+        | Pfx _ -> "pfx filepath"
+        | Password _ -> "password for pfx file"
+        | File _ -> "file which will be checked for having been signed by the given pfx file"
+  and PrintArgs =
+  | [<Mandatory>] Password of string
+  | [<MainCommand; ExactlyOnce; Last>] Pfx of ``pfx filepath``:string
+  with
+    interface IArgParserTemplate with
+      member this.Usage =
+        match this with
+        | Password _ -> "password for pfx file"
+        | Pfx _ -> "pfx filepath"
+  and SignArgs =
+  | [<Mandatory>] Pfx of ``pfx filepath``:string
+  | [<Mandatory>] Password of string
+  | [<MainCommand; ExactlyOnce; Last>] Files of ``files to check``:string list
+  with
+    interface IArgParserTemplate with
+      member this.Usage =
+        match this with
+        | Pfx _ -> "pfx filepath"
+        | Password _ -> "password for pfx file"
+        | Files _ -> "files which will be checked for having been signed by the given pfx file"
+  and NotaryArgs =
+  | [<CliPrefix(CliPrefix.None)>] Detect of ParseResults<DetectArgs>
+  | [<CliPrefix(CliPrefix.None)>] Print of ParseResults<PrintArgs>
+  | [<CliPrefix(CliPrefix.None)>] Sign of ParseResults<SignArgs>
+  | [<Inherit>] Certutil of path:string
+  | [<Inherit>] Signtool of path:string
+  | [<Inherit; AltCommandLine("-v"); Hidden>] Verbose // TODO
+  | [<Inherit; AltCommandLine("-q"); Hidden>] Quiet // TODO
+  with
+    interface IArgParserTemplate with
+      member this.Usage =
+        match this with
+        | Detect _ -> "detect whether a file is already signed by the specified pfx file"
+        | Print _ -> "print the sha1 hash of a given pfx certificate file"
+        | Sign _ -> "sign files with the given pfx certificate only if they're not already signed by that same certificate"
+        | Certutil _ -> "certutil.exe filepath"
+        | Signtool _ -> "signtool.exe filepath"
+        | Verbose -> "Print more detailed output to console"
+        | Quiet -> "Print no output to console"
 
-    let getToolPaths (parseResults: ParseResults<NotaryArgs>) =
-      Notary.Tools.buildPaths
-        (parseResults.TryGetResult <@ NotaryArgs.Certutil @>)
-        (parseResults.TryGetResult <@ NotaryArgs.Signtool @>)
+  let getToolPaths (parseResults: ParseResults<NotaryArgs>) =
+    Notary.Tools.buildPaths
+      (parseResults.TryGetResult <@ NotaryArgs.Certutil @>)
+      (parseResults.TryGetResult <@ NotaryArgs.Signtool @>)
 
-    let tryGetSubCommand (parseResults: ParseResults<NotaryArgs>) =
-      // It would be nice if these were actually just filtered from
-      // TryGetSubCommand; they're definitely not subcommands...
-      match parseResults.TryGetSubCommand() with
-      | Some (Certutil _)
-      | Some (Signtool _)
-      | Some (Verbose)
-      | Some (Quiet) -> None
-      | subCommand -> subCommand
+  let tryGetSubCommand (parseResults: ParseResults<NotaryArgs>) =
+    // It would be nice if these were actually just filtered from
+    // TryGetSubCommand; they're definitely not subcommands...
+    match parseResults.TryGetSubCommand() with
+    | Some (Certutil _)
+    | Some (Signtool _)
+    | Some (Verbose)
+    | Some (Quiet) -> None
+    | subCommand -> subCommand

--- a/src/Notary/Lib.fs
+++ b/src/Notary/Lib.fs
@@ -8,9 +8,9 @@ module Lib =
   let getPfxCertHash certutil password pfx =
     let { stdOut = stdOut } =
       pfx
-      |> sprintf "-dump -p \"%s\" %s" password
+      |> Tools.Certutil.generateDumpArgs password
       |> Shell.createStartInfo certutil
-      |> Shell.printCommandFiltered (fun str -> Regex.Replace(str, "-p [^ ]+ ", "-p [FILTERED] "))
+      |> Shell.printCommandFiltered Tools.Certutil.filterPassword
       |> Shell.runSync
       |> Shell.raiseIfExitNonzero
 
@@ -77,7 +77,7 @@ module Lib =
 
       args
       |> Shell.createStartInfo signtool
-      |> Shell.printCommandFiltered (fun str -> Regex.Replace(str, "/p [^ ]+ ", "/p [FILTERED] "))
+      |> Shell.printCommandFiltered Tools.Signtool.filterPassword
       |> Shell.runSync
       |> Shell.ifExitZero ProcessResult.PrintStdOut
       |> Shell.raiseIfExitNonzero

--- a/src/Notary/Lib.fs
+++ b/src/Notary/Lib.fs
@@ -57,8 +57,18 @@ module Lib =
       |> fun (toSkip, toSign) ->
           (Array.length toSkip, List.ofArray toSign)
 
-    if skipCount > 0 then
-      printfn "Skipping %d file(s) that have already been signed with %s" skipCount pfx
+    match skipCount with
+    | 0 -> None
+    | 1 -> Some ("file", "has")
+    | _ -> Some ("files", "have")
+    |> Option.iter (fun (fileOrFiles, hasOrHave) ->
+        printfn
+          "Skipping %d %s which %s already been signed with %s"
+          skipCount
+          fileOrFiles
+          hasOrHave
+          pfx
+    )
 
     if List.isEmpty filesToSign then
       ()

--- a/src/Notary/Notary.fsproj
+++ b/src/Notary/Notary.fsproj
@@ -41,8 +41,8 @@
   <ItemGroup>
     <Compile Include="AssemblyInfo.fs" />
     <Compile Include="Shell.fs" />
-    <Compile Include="Lib.fs" />
     <Compile Include="Tools.fs" />
+    <Compile Include="Lib.fs" />
     <Compile Include="Args.fs" />
     <Compile Include="Program.fs" />
     <None Include="App.config" />

--- a/src/Notary/Program.fs
+++ b/src/Notary/Program.fs
@@ -3,6 +3,7 @@ open Notary
 open Notary.CommandLine.Args
 open Notary.Shell
 open System
+open Argu
 
 type Exit =
 | Ok = 0

--- a/src/Notary/Tools.fs
+++ b/src/Notary/Tools.fs
@@ -1,6 +1,7 @@
 namespace Notary
 
 module Tools =
+  open Argu
   open System
 
   type Paths =
@@ -21,3 +22,56 @@ module Tools =
       certutil = certutil ?> defaultPaths.certutil
       signtool = signtool ?> defaultPaths.signtool
     }
+
+  let private _printCliArgsFlat<'a when 'a :> IArgParserTemplate> =
+    ArgumentParser.Create<'a>().PrintCommandLineArgumentsFlat
+
+  module Signtool =
+    type private VerifyArgs =
+    | [<Mandatory; First; CliPrefix(CliPrefix.None)>] Verify
+    | [<CustomCommandLine("/v")>] Verbose
+    | [<Mandatory; CustomCommandLine("/all")>] All
+    | [<Mandatory; CustomCommandLine("/pa")>] Pa
+    | [<Mandatory; CustomCommandLine("/sha1")>] Sha1 of string
+    | [<Mandatory; MainCommand; ExactlyOnce; Last>] Filepath of string
+    with
+      interface IArgParserTemplate with member this.Usage = ""
+
+    type private SignArgs =
+    | [<Mandatory; First; CliPrefix(CliPrefix.None)>] Sign
+    | [<CustomCommandLine("/v")>] Verbose
+    | [<Mandatory; CustomCommandLine("/as")>] AppendSignature
+    | [<Mandatory; CustomCommandLine("/fd")>] FileDigestAlgo of string
+    | [<Mandatory; CustomCommandLine("/td")>] TimestampDigestAlgo of string
+    | [<Mandatory; CustomCommandLine("/tr")>] TimestampServerUrl of string
+    | [<Mandatory; CustomCommandLine("/f")>] Pfx of string
+    | [<Mandatory; CustomCommandLine("/p")>] Password of string
+    | [<MainCommand; ExactlyOnce; Last>] FilesToSign of string list
+    with
+      interface IArgParserTemplate with member this.Usage = ""
+
+    let generateVerifyArgs sha1 filePath =
+      _printCliArgsFlat <| [
+        Verify
+        VerifyArgs.Verbose
+        All
+        Pa
+        Sha1 sha1
+        Filepath filePath
+      ]
+
+    let generateSignArgs fileDigestAlgo timestampDigestAlgo timestampServerUrl pfx password filesToSign =
+      _printCliArgsFlat <| [
+        Sign
+        Verbose
+        AppendSignature
+        FileDigestAlgo fileDigestAlgo
+        TimestampDigestAlgo timestampDigestAlgo
+        TimestampServerUrl timestampServerUrl
+        Pfx pfx
+        Password password
+        FilesToSign filesToSign
+      ]
+
+  module Certutil =
+    ()

--- a/src/Notary/Tools.fs
+++ b/src/Notary/Tools.fs
@@ -3,6 +3,7 @@ namespace Notary
 module Tools =
   open Argu
   open System
+  open System.Text.RegularExpressions
 
   type Paths =
     {
@@ -73,5 +74,23 @@ module Tools =
         FilesToSign filesToSign
       ]
 
+    let filterPassword commandStr =
+      Regex.Replace(commandStr, "/p [^ ]+ ", "/p [FILTERED] ")
+
   module Certutil =
-    ()
+    type private DumpArgs =
+    | [<Mandatory; First; CliPrefix(CliPrefix.Dash)>] Dump
+    | [<Mandatory; CustomCommandLine("-p")>] Password of string
+    | [<Mandatory; MainCommand; ExactlyOnce; Last>] Pfx of string
+    with
+      interface IArgParserTemplate with member this.Usage = ""
+
+    let generateDumpArgs password pfx =
+      _printCliArgsFlat <| [
+        Dump
+        Password password
+        Pfx pfx
+      ]
+
+    let filterPassword commandStr =
+      Regex.Replace(commandStr, "-p [^ ]+ ", "-p [FILTERED] ")

--- a/src/Notary/Tools.fs
+++ b/src/Notary/Tools.fs
@@ -34,7 +34,7 @@ module Tools =
     | [<Mandatory; CustomCommandLine("/all")>] All
     | [<Mandatory; CustomCommandLine("/pa")>] Pa
     | [<Mandatory; CustomCommandLine("/sha1")>] Sha1 of string
-    | [<Mandatory; MainCommand; ExactlyOnce; Last>] Filepath of string
+    | [<Mandatory; MainCommand; ExactlyOnce; Last>] Filepaths of string list
     with
       interface IArgParserTemplate with member this.Usage = ""
 
@@ -51,14 +51,15 @@ module Tools =
     with
       interface IArgParserTemplate with member this.Usage = ""
 
-    let generateVerifyArgs sha1 filePath =
+
+    let generateVerifyArgs sha1 filePaths =
       _printCliArgsFlat <| [
         Verify
         VerifyArgs.Verbose
         All
         Pa
         Sha1 sha1
-        Filepath filePath
+        Filepaths filePaths
       ]
 
     let generateSignArgs fileDigestAlgo timestampDigestAlgo timestampServerUrl pfx password filesToSign =


### PR DESCRIPTION
Notable changes:
* Some nicer CLI messaging
* Now use Argu to build `signtool`/`certutil` arg strings, instead of just `sprintf`
* Now only make one call to `signtool verify`, providing `n` files, instead of making `n` calls with one file each.
