### PR TITLE
chore: Remove NuGet.CommandLine

### DIFF
--- a/paket.dependencies
+++ b/paket.dependencies
@@ -5,4 +5,3 @@ nuget argu
 nuget FAKE
 nuget FSharp.Core
 nuget fsharp.faketargets
-nuget nuget.commandline

--- a/paket.lock
+++ b/paket.lock
@@ -5,4 +5,3 @@ NUGET
     FAKE (4.63)
     FSharp.Core (4.2.3)
     FSharp.FakeTargets (0.11.1)
-    NuGet.CommandLine (4.3)


### PR DESCRIPTION
There's no need for it.